### PR TITLE
Uses Event Log

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ tell it to look for the profile in C:\Users. When it can't find the deleted prof
 profile folder and then deleting it so nothing is left behind.
 
 The PowerShell script is designed to be run on a schedule to keep up with the cleaning up of any users added. It can also be used in one off situations as well. While this has been designed for roaming profiles,
-I would imagine that it would work just fine for local profiles as well. Keeping in mind that any local profiles that are deleted are gone for good. <b>Use caution and use the SafeUsers variable</b> at the top of the script to ensure safety.
+it works just fine for local profiles as well. Keeping in mind that any local profiles that are deleted are gone for good. <b>Use caution and use the SafeUsers variable</b> at the top of the script to ensure safety.
 
 [![CodeFactor](https://www.codefactor.io/repository/github/compuvin/removeusers/badge)](https://www.codefactor.io/repository/github/compuvin/removeusers)

--- a/RemoveUsers.ps1
+++ b/RemoveUsers.ps1
@@ -54,7 +54,7 @@ Get-EventLog -LogName "Security" -InstanceId 4624 -ErrorAction "SilentlyContinue
 
 foreach ($item in $UsersToRemove)
 {
-    if ($SafeUsers.Contains($item.Name) -eq 0)
+    if ($SafeUsers.Contains($item.Name) -eq 0 -and (($item.Name).Split("." + ($env:USERDNSDomain).Split(".")[0])[0]).Length -gt 0 -and $SafeUsers.Contains(($item.Name).Split("." + ($env:USERDNSDomain).Split(".")[0])[0]) -eq 0)
     { 
         $Key | ForEach-Object {
             If($_.ProfileImagePath.ToLower() -match $item.Name)

--- a/RemoveUsers.ps1
+++ b/RemoveUsers.ps1
@@ -4,7 +4,7 @@ $SafeUsers = "Public", "Default", "Default.migrated", "juser" #User profiles to 
 #####
 
 $UsersToRemove = Get-ChildItem "C:\Users" |? {$_.psiscontainer -and $_.lastwritetime -le (get-date).adddays(-$DaysBack)}
-$UsersFromReg = Get-ChildItem "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList"
+$UsersFromReg = Get-ChildItem "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList"  | Where-Object { (-not($_ -match 'S-1-5-18|S-1-5-19|S-1-5-20')) } #Users from registry, ignoring system accounts
 $Key = $UsersFromReg | Get-ItemProperty -name "ProfileImagePath"
 
 


### PR DESCRIPTION
Uses code from PDQ to analyze the event log and remove users from the mix that nave logged in within the time period given. You see, the script was working great for roaming profiles but not for non-roaming profiles as it was deleting users that were most certainly active.